### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/assume-role.rb
+++ b/assume-role.rb
@@ -3,7 +3,6 @@ class AssumeRole < Formula
   desc ""
   homepage ""
   version "0.4.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/danielthank/assume-role/releases/download/v0.4.1/assume-role_0.4.1_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
With the newest homebrew version I was not able to install your amazing tool.
The error message was
```
Error: Invalid formula: /opt/homebrew/Library/Taps/danielthank/homebrew-tap/assume-role.rb
assume-role: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the danielthank/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/danielthank/homebrew-tap/assume-role.rb:6

Error: Cannot tap danielthank/tap: invalid syntax in tap!
```
After applying the proposed changes locally, everything works perfectly.
Source of the solution I found here: https://github.com/Azure/homebrew-functions/pull/90/files

(I really don't know much about homebrew and how the taps work in general, so I am just proposing what was working. No clue, if there needs to be some backwards compatibility or something)

Thank you for having a look!